### PR TITLE
Create the first GUI for RocketType

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A local keylogger to track typing statistics like WPM on Windows.
 
 The log file can be imported into other software like Pandas, Excel, PowerBI etc. to calculate statistics over time etc.
 
-_DISCLAIMER: Currently **all** keypresses are logged, including passwords etc. See: [Avoid storing passwords](https://github.com/janmechtel/rockettype/issues/6)_ 
+_DISCLAIMER: Currently **all** keypresses are logged, including passwords etc. See: [Avoid storing passwords](https://github.com/janmechtel/rockettype/issues/6)_
 
 If you need a feature, please create an [issue](https://github.com/janmechtel/rockettype/issues).
 
@@ -25,7 +25,7 @@ time delta key application
 
 `delta` are the milliseconds since the last keypress
 
-### Hotkeys with notifications 
+### Hotkeys with notifications
 * `Ctrl+Alt+R` - Toggles recording. Use it to temporarily disable the recording for passwords and such,
 * `Ctrl+Alt+X` - Exits
 
@@ -53,14 +53,14 @@ The current scope is **convenient and safe logging** for statistics and personal
 ### Epic I: correct finger?
 
 For faster touch typing the correct finger should be used. However, to _unlearn_ using the wrong finger is quite a challenge, especially when the habit is in muscle memory already. The idea is to:
- 
+
 - Record a webcam shot on each keypress
 - Analyze whether the correct finger was used to press the key either through openCV or deep learning
 - Prevent the wrong key to register
 
 ### Epic II: Auto-Correct
 
-Typos are a big slow down for many typists. Auto-Correct is a way to combat that. 
+Typos are a big slow down for many typists. Auto-Correct is a way to combat that.
 
 - Show most common typos? (Idea: Learn typos on backspace presses)
 - Auto-correct typos - probably this can be more aggressive compared to other tools.
@@ -83,7 +83,7 @@ Typos are a big slow down for many typists. Auto-Correct is a way to combat that
 
 1. Install Python 3
 2. Clone Repository
-3. Install requirements: `pip install pynput win10toast`
+3. Install requirements: `pip install pynput win10toast PyQt5`
 4. Run `python logger.pyw`
 
 Optional: add to your autorun (Win+R type `shell:startup` + right-click drag `logger.pyw` into the folder and select "Create shortcut here"
@@ -94,4 +94,4 @@ Optional: add to your autorun (Win+R type `shell:startup` + right-click drag `lo
 1. Install NSIS (?)
 2. Make sure you hack pyapp.nsi as descriped in the my_pyapp.nsi
 3. `python -m nsist installer.cfg`
-4. [Create a new release](https://github.com/janmechtel/rockettype/releases/new) and upload the .exe 
+4. [Create a new release](https://github.com/janmechtel/rockettype/releases/new) and upload the .exe

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ time delta key application
 
 `delta` are the milliseconds since the last keypress
 
+As of right now, keypresses will only store the time, delta, and application
+and record `'hidden'` for each key press. To record the keypresses, create a
+file in the automatically generated output folder called `DEBUG`. 
+
 ### Hotkeys with notifications
 * `Ctrl+Alt+R` - Toggles recording. Use it to temporarily disable the recording for passwords and such,
 * `Ctrl+Alt+X` - Exits

--- a/installer.cfg
+++ b/installer.cfg
@@ -13,11 +13,12 @@ version=3.8.5
 # These must have wheels on PyPI:
 # https://pynsist.readthedocs.io/en/latest/cfgfile.html#include-section
 # Look them up here: https://pypi.org/
-pypi_wheels = pynput==1.6.8 
+pypi_wheels = pynput==1.6.8
     win10toast==0.9
     six==1.15.0
     setuptools==49.6.0
     pywin32==228
+    PyQt5==5.15.0
 
 # Other files and folders that should be installed
 # files = LICENSE

--- a/logger_model.py
+++ b/logger_model.py
@@ -1,0 +1,65 @@
+from PyQt5.QtCore import *
+import logger_view
+
+class gui:
+    def __init__(self, logger_thread, env, env_lock):
+        self.app = logger_view.init_app()
+        self.app.setQuitOnLastWindowClosed(False) # Keep open with tray icon
+
+
+        # Should be the objects themselves, not copies, therefore editing will
+        # change the original
+        self.env = env
+        self.env_lock = env_lock
+
+        # Items for (re)displaying and changing window elements
+        if_bp = logger_view.init_interface()
+        self.status = if_bp[0]
+        self.wpm = if_bp[1]
+        self.window = if_bp[2]
+
+        # Items for showing the system tray and controlling buttons
+        st_bp = logger_view.init_systray()
+        self.show = st_bp[0]
+        self.pause = st_bp[1]
+        self.exit = st_bp[2]
+        self.tray = st_bp[3] # This is to prevent the garbage collector from deleting it
+
+        self.pause.triggered.connect(self.pause_app)
+        self.exit.triggered.connect(self.app.exit)
+        self.show.triggered.connect(self.show_window)
+
+        self.logger = logger_thread
+
+        self.logger.finished.connect(self.app.exit)
+        self.logger.start()
+
+    def show_window(self, q):
+        self.window.show()
+        self.wpm.setText(logger_view.get_wpm_by_day())
+        self.env_lock.acquire()
+        # TODO: Update this when window is open and should_log changes,
+        # either with event or by setting it each time that happens in the code
+        status_str = "Enabled" if self.env['should_log'] else "Disabled"
+        self.status.setText(status_str)
+        self.env_lock.release()
+
+    def pause_app(self, q):
+        self.env_lock.acquire()
+        self.env['should_log'] = not self.env['should_log']
+        enabled_string = "Enabled" if self.env['should_log'] else "Disabled"
+        # Show notification
+        self.env['toaster'].show_toast(f"RocketType {enabled_string}",
+            " ",
+            icon_path="icon.ico", duration=3, threaded=True)
+        self.env_lock.release()
+
+    def exec_(self):
+        self.app.exec_()
+
+class logger_thread(QThread):
+    def set_func(self, start_logger):
+        self.func = start_logger
+
+    def run(self):
+        self.func()

--- a/logger_view.py
+++ b/logger_view.py
@@ -1,0 +1,37 @@
+from PyQt5.QtWidgets import *
+from PyQt5.QtGui import *
+import stats
+
+def init_app():
+    return QApplication([])
+
+def init_interface():
+    window = QWidget()
+    status = QLabel('Running & Recording keypresses')
+
+    statstr = get_wpm_by_day()
+    wpm = QLabel(statstr)
+
+    layout = QVBoxLayout()
+    layout.addWidget(status)
+    layout.addWidget(wpm)
+
+    window.setLayout(layout)
+
+    return (status, wpm, window)
+
+def get_wpm_by_day():
+    statstr = str(stats.get_stats())
+    statstr = "\n".join(statstr.split("\n")[1:-1])
+    return "WPM by day:\n" + statstr
+
+def init_systray():
+    tray = QSystemTrayIcon(QIcon("icon.ico"))
+    menu = QMenu()
+    pauseAction = menu.addAction("Toggle Recording")
+    statsAction = menu.addAction("See statistics")
+    exitAction = menu.addAction("Exit")
+    tray.setContextMenu(menu)
+    tray.show()
+
+    return (statsAction, pauseAction, exitAction, tray)


### PR DESCRIPTION
This ended up taking quite a bit of code and two and a half hours to complete, mostly just because of how much code had to be changed. Because both the keylogger and the command to show the window are blocking, I had to move one of them to a separate thread and therefore also had to make sure that they can communicate without trying to write to the same memory at the same time. 

Worth it though. We have a tray icon, three buttons when right clicked, and a very minimal display with the stats and status that updates each time the window is opened (TODO: Update status when rockettype is paused rather than just when the window is opened). Additionally, everything can be called with functions and mostly everything is handled with models (exception is the `env` dictionary that has a bunch of stuff that used to be global). 

Please give it a go, I think you'll be pretty satisfied with the results. 